### PR TITLE
Feat/i2c write

### DIFF
--- a/DRIVERS/ETH_16Z077/DRIVER/men_16z077_eth.c
+++ b/DRIVERS/ETH_16Z077/DRIVER/men_16z077_eth.c
@@ -157,6 +157,21 @@ static PHY_DEVICE_TBL z077PhyAttachTbl[] = {
 	{ 0xffff, ""}
 };
 
+/* I2C Message - used for pure i2c transaction, also from /dev interface */
+typedef struct z77_i2c_msg_st
+{
+	u16 addr;				/**< slave address			*/
+	u32 flags;				/**< flags for communication		*/
+#define I2C_M_TEN			0x0010	/**< we have a ten bit chip address	*/
+#define I2C_M_WR			0x0000	/**< write access			*/
+#define I2C_M_RD			0x0001	/**< read access			*/
+#define I2C_M_NOSTART			0x4000	/**< don't send start bit		*/
+#define I2C_M_REV_DIR_ADDR		0x2000
+	u16 len;				/**< msg length				*/
+	u8 *buf;				/**< pointer to msg data		*/
+} z77_i2c_msg_t;
+
+
 /**
  * z077_private: main data struct for the driver \n
  * this struct keeps all data for a per-IP-core instance of 16Z077/87
@@ -194,10 +209,6 @@ struct z77_private {
 	u32 serialnr;
 	/*!< board identifier of this eth */
 	u32 board;
-	/*!< SMB2 descriptor for EEPROM */
-	SMB_DESC_PORTCB smb2desc;
-	/*!< SMB2 Handle */
-	void *smbHdlP;
 	/*!< process context resetting (ndo_tx_timeout) */
 	struct work_struct reset_task;
 	/*!< period timer for linkchange poll */
@@ -659,11 +670,16 @@ static const struct net_device_ops z77_netdev_ops = {
 static int z77_sda_in(void *dat)
 {
 	int pin=0;
-	volatile unsigned int tmp = 0, i = 0;
+	volatile unsigned int tmp = 0;
 
-	for (i=0; i < 2; i++) {
-		tmp = Z77READ_D32( dat, Z077_REG_SMBCTRL);
-	}
+	/* Set SDA to open drain */
+	tmp = Z77READ_D32(dat, Z077_REG_SMBCTRL);
+	tmp |= SMB_REG_SDA;
+	Z77WRITE_D32(dat, Z077_REG_SMBCTRL, tmp);
+	udelay(10);
+
+	/* Read SDA */
+	tmp = Z77READ_D32(dat, Z077_REG_SMBCTRL);
 
 	pin = (tmp & SMB_REG_SDA) ? 1 : 0;
 	return pin;
@@ -682,12 +698,37 @@ static int z77_sda_out(void *dat, int pinval)
 	volatile unsigned int tmp = Z77READ_D32( dat, Z077_REG_SMBCTRL);
 
 	if (pinval)
-		tmp |=SMB_REG_SDA;
+		tmp |= SMB_REG_SDA;
 	else
-		tmp &=~SMB_REG_SDA;
+		tmp &= ~SMB_REG_SDA;
 
-	Z77WRITE_D32( dat, Z077_REG_SMBCTRL, tmp);
+	Z77WRITE_D32(dat, Z077_REG_SMBCTRL, tmp);
 	return(0);
+}
+
+/******************************************************************************
+ ** z77_sda_in - read SCL Pin on SMB Register
+ *
+ * \param dat	\IN general purpose data, the Z87 instances base address
+ *
+ * \return		pin state: 0 or 1
+ */
+static int z77_scl_in(void *dat)
+{
+	int pin=0;
+	volatile unsigned int tmp = 0;
+
+	/* Set SCL to open drain */
+	tmp = Z77READ_D32(dat, Z077_REG_SMBCTRL);
+	tmp |= SMB_REG_SCL;
+	Z77WRITE_D32(dat, Z077_REG_SMBCTRL, tmp);
+	udelay(10);
+
+	/* Read SCL */
+	tmp = Z77READ_D32(dat, Z077_REG_SMBCTRL);
+
+	pin = (tmp & SMB_REG_SCL) ? 1 : 0;
+	return pin;
 }
 
 /******************************************************************************
@@ -2089,7 +2130,7 @@ static int z77_open(struct net_device *dev)
  * \param dev			\IN net_device struct for this NIC
  * \param skb			\IN struct skbuf with data to transmit
  *
- * \return 				0 or error code
+ * \return 			0 or error code
  */
 static int z77_send_packet(struct sk_buff *skb, struct net_device *dev)
 {
@@ -2238,102 +2279,590 @@ static int z77_send_packet(struct sk_buff *skb, struct net_device *dev)
 }
 
 /*******************************************************************/
-/** perform a SMBus cycle on EEprom
-*
-* \param dev	\IN net_device struct for this NIC
-* \param c	    \IN command char to describe which cycle to perform
-*
-* \return 0 or 1 when cycle='G' or 0xffff
-*/
-static unsigned int smb_cycle(struct net_device *dev, unsigned char c)
+/** delay for each I2C cycle
+ *
+ */
+static void z77_i2c_delay(void)
 {
-	int i;
-	unsigned int val=0;
-	int symboltype=-1;
-	unsigned char chip[4][2][3] = { /* signal every cycle as a triplet */
-		{{1,1,1},  /* SCL */   /* START */
-		 {1,0,0}}, /* SDA */
-		{{1,1,1},  /* STOP */
-		 {0,1,1}},
-		{{0,1,0},  /* '1' or ACK */
-		 {1,1,1}},
-		{{0,1,0},  /* '0' or low */
-		 {0,0,0}}
-	};
-	switch( c ) {
-	case 'S': /* START is SDA = 1,0,0 while SCL high (1,1,1) */
-		symboltype =  0;
-		break;
-	case 'O': /* STOP is SDA = 0,1,1 while SCL high (1,1,1) */
-		symboltype =  1;
-		break;
-	case 'A':
-	case '1':
-	case 'R':
-	case 'G': /* these are SDA = 1,1,1 (tristate) while a SCL pulse(0,1,0)*/
-		symboltype =  2;
-		break;
-	case 'W':
-	case '0': /* these are SDA = 0,0,0 (
-		     driven low) while a SCL pulse(0,1,0)*/
-		symboltype =  3;
-		break;
-	case 'P':
-		udelay(50); /* Pause: change to other value if desired */
-		break;
-	default:
-		printk("*** intern error (SMB sequence wrong char '%c')\n",c);
-	}
-	if (symboltype >= 0) {
-		for (i=0; i< 3; i++) {
-			udelay(50);
-			 /* for 'G' cycles, store SDA */
-			if ( (i==1) && (c == 'G'))
-				val = z77_sda_in(Z077_BASE);
-
-			z77_scl_out(Z077_BASE, chip[symboltype][0][i] );
-			z77_sda_out(Z077_BASE, chip[symboltype][1][i] );
-		}
-	}
-	return (c == 'G') ? val : 0xffff;
+	udelay(50);
 }
 
 /*******************************************************************/
-/** Read a byte from MAC EEPROM directly attached to this Z87
+/** free the I2C bus 
  *
- * \param dev		\IN net_device struct for this NIC
- * \param offset	\IN position of byte to read
+ * \param dev			\IN net_device struct for this NIC
  *
- * \return byte value at this offset in EEPROM
  * \brief
- *  Every cycle of the SMB access is coded in a descriptive string:
- *	S: Start    0:   0
- *	O: Stop     1:   1
- *	R: Read  	A:   Ack (SDA just set high, no check!)
- *	W: Write    P:   Pause 50 us
- *	G: Get bit (=reads SDA)
- *  Attention: this assumes that exactly one byte is read (8x'G' in a row)!
+ *  Free the bus from busy devices by setting SDA high
+ *  and clock 20 times.
  */
-static unsigned char z77_read_byte_data(struct net_device *dev,
-					unsigned int offset )
+static void z77_i2c_freeBus(struct net_device *dev)
 {
-	unsigned int i=0, j=7;
-	unsigned char byte=0;
-	unsigned char sequence[]="S1010000WA00000000AS1010000RAGGGGGGGGAO\0";
+	int i;
 
-	for (i=0; i < 8; i++) /* insert offset in offset write phase above */
-		sequence[10 + i] = (offset & (0x80>>i)) ? '1' : '0';
-	i=0;
-	while(sequence[i]) {
-		if (sequence[i] == 'G') /* G: Get a bit (sda_in) */
-			 /* assumes 8x'G'! */
-			byte |= smb_cycle(dev, sequence[i++]) << (j--);
-		else
-			/* other cycles: clocked out straightforward */
-			smb_cycle(dev, sequence[i++]);
+	z77_sda_out(Z077_BASE, 1);
+	z77_i2c_delay();
+	for (i = 0; i < 20; i++)
+	{
+		z77_scl_out(Z077_BASE, 1);
+		z77_i2c_delay();
+		z77_scl_out(Z077_BASE, 0);
+		z77_i2c_delay();
 	}
-	return byte;
+	z77_scl_out(Z077_BASE, 1);
+	z77_i2c_delay();
 }
+
+/*******************************************************************/
+/** set RESTART condition
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Set RESTART condition 
+ *          ____
+ *    SDA       |_
+ *            ___
+ *    SCL  X_|
+ *
+ */
+static int z77_i2c_start(struct net_device *dev)
+{
+	z77_scl_out(Z077_BASE, 0);
+	z77_i2c_delay();
+	z77_scl_out(Z077_BASE, 1);
+
+	/* check SCL is high */
+	z77_i2c_delay();
+	if( !z77_scl_in(Z077_BASE) )
+		return( SMB_ERR_BUSY );
+
+	/* check SDA is high */
+	if( !z77_sda_in(Z077_BASE) )
+	{
+		z77_i2c_freeBus( dev );
+		if( !z77_sda_in(Z077_BASE) )
+			return( SMB_ERR_BUSY );
+	}
+
+	if( z77_sda_out(Z077_BASE, 0) )
+		return( SMB_ERR_COLL );
+	else
+		z77_i2c_delay();
+	return( 0 );
+}
+
+/*******************************************************************/
+/** set STOP condition
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Set STOP condition 
+ *              __
+ *    SDA  X___|    
+ *            ___
+ *    SCL  X_|
+ *
+ */
+static int z77_i2c_stop(struct net_device *dev)
+{
+	z77_sda_out(Z077_BASE, 0);
+	z77_i2c_delay();
+	z77_scl_out(Z077_BASE, 0);
+	z77_i2c_delay();
+
+	if( z77_scl_out(Z077_BASE, 1) )
+		return( SMB_ERR_COLL );
+
+	z77_i2c_delay();
+	if( z77_sda_out(Z077_BASE, 1) )
+		return( SMB_ERR_BUSY );
+	else
+		return( 0 );
+}
+
+/*******************************************************************/
+/** check the bit for acknowledge
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Check acknowledge 
+ *         _     __
+ *    SDA   |___|    expected 
+ *             ___
+ *    SCL  ___|
+ *
+ */
+static int z77_i2c_checkAckn(struct net_device *dev)
+{
+	int error = 0;
+
+	z77_scl_out(Z077_BASE, 0);
+	z77_i2c_delay();
+	z77_sda_out(Z077_BASE, 1);
+	z77_i2c_delay();
+
+	if( z77_scl_out(Z077_BASE, 1) )
+		return( SMB_ERR_COLL );
+
+	z77_i2c_delay();
+
+	if( z77_sda_in(Z077_BASE) )
+		error = SMB_ERR_NO_DEVICE ;
+
+	return( error );
+}
+
+/*******************************************************************/
+/** set the bit for acknowledge
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Set acknowledge 
+ *         _     __
+ *    SDA   |___|    set
+ *             ___
+ *    SCL  ___|
+ *
+ */
+static int z77_i2c_setAckn(struct net_device *dev)
+{
+	z77_scl_out(Z077_BASE, 0);
+	z77_i2c_delay();
+	z77_sda_out(Z077_BASE, 0);
+	z77_i2c_delay();
+
+	if( z77_scl_out(Z077_BASE, 1) )
+		return( SMB_ERR_COLL );
+
+	z77_i2c_delay();
+	return( 0 );
+}
+
+/*******************************************************************/
+/** set the bit for not acknowledge
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Set not acknowledge 
+ *         _______
+ *    SDA            set
+ *             ___
+ *    SCL  ___|
+ *
+ */
+static int z77_i2c_notAckn(struct net_device *dev)
+{
+	z77_scl_out(Z077_BASE, 0);
+	z77_sda_out(Z077_BASE, 1);
+	z77_i2c_delay();
+
+	if( z77_scl_out(Z077_BASE, 1) )
+		return( SMB_ERR_COLL );
+
+	z77_i2c_delay();
+	return( 0 );
+}
+
+/*******************************************************************/
+/** send a byte
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Send a byte 
+ *         _ ___ _
+ *    SDA  _X___X_   set for each bit
+ *             ___
+ *    SCL  ___|
+ *
+ */
+static int z77_i2c_sendByte(struct net_device *dev, u8 val)
+{
+	u8 mask;
+	int error = 0;
+
+	mask = 0x80;
+	while( mask )
+	{
+		if( z77_scl_out(Z077_BASE, 0) ){
+			error = SMB_ERR_COLL;
+			goto out_cleanup;
+		}
+		z77_i2c_delay();
+
+		if( z77_sda_out(Z077_BASE, (mask & val) ? 1 : 0) ) {
+			error = SMB_ERR_BUSY;
+			goto out_cleanup;
+		}
+		z77_i2c_delay();
+
+		if( z77_scl_out(Z077_BASE, 1) ){
+			error = SMB_ERR_COLL;
+			goto out_cleanup;
+		}
+		z77_i2c_delay();
+
+		mask >>= 1;
+	}/*while*/
+out_cleanup:
+	/* finish always with setting SCL high only happens in case off error*/
+	if( error && !z77_scl_in(Z077_BASE) )
+		z77_scl_out(Z077_BASE, 1);
+	return( error );
+}
+
+/*******************************************************************/
+/** read a byte
+ *
+ * \param dev			\IN net_device struct for this NIC
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Read a byte 
+ *         _ ___ _
+ *    SDA  _X___X_   read before SCL risig edge for each bit
+ *             ___
+ *    SCL  ___|
+ *
+ */
+static int z77_i2c_readByte(struct net_device *dev, u8 *valP)
+{
+	u8 mask;
+	int error = 0;
+
+	*valP = 0xFF;
+	mask = 0x80;
+
+	if( z77_scl_out(Z077_BASE, 0)){
+		error = SMB_ERR_COLL;
+		goto out_cleanup;
+	}
+	/* switch port to input */
+	z77_sda_in(Z077_BASE);
+	z77_i2c_delay();
+
+	while( mask )
+	{
+		if( z77_scl_out(Z077_BASE, 0)){
+			error = SMB_ERR_COLL;
+			goto out_cleanup;
+		}
+
+		z77_i2c_delay();
+		if( !z77_sda_in(Z077_BASE) )
+			*valP &= ~mask;
+
+		z77_i2c_delay();
+		if( z77_scl_out(Z077_BASE, 1) ){
+			error = SMB_ERR_COLL;
+			goto out_cleanup;
+		}
+
+
+		z77_i2c_delay();
+		mask >>= 1;
+	}
+
+out_cleanup:
+	/* finish always with setting SCL high only happens in case off error*/
+	if( error && !z77_scl_in(Z077_BASE) )
+		z77_scl_out(Z077_BASE, 1);
+	return( error );
+}
+
+/*******************************************************************/
+/** read a defined length of bytes
+ *
+ * \param dev			\IN net_device struct for this NIC
+ * \param msg			\INOUT i2c message struct for
+ *				this transfer. Received data will
+ *				be stored in this message
+ * \param stop			\IN if stop is set. the access is
+ *				terminated after the transfer
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Read a defined length of bytes
+ */
+int z77_i2c_read_msg(struct net_device *dev, struct z77_i2c_msg_st *msg, int stop)
+{
+	u32 error = 0, error1  = 0, stopErr = 0;
+	u32 len = msg->len;
+	u8 *buf = msg->buf;
+	*buf = 0xFF;
+
+	if( (error = z77_i2c_start( dev )) )
+		goto out_cleanup;
+
+	/* send device address */
+	if( (error = z77_i2c_sendByte( dev, msg->addr | SMB_READ )) )
+		goto out_cleanup;
+
+	if( (error = z77_i2c_checkAckn( dev )) )
+		goto out_cleanup;
+
+	/* read data */
+	while( --len ) {
+		/* OSS_MikroDelay() is blocking for some OS
+		 * give other tasks a chance:-) */
+		udelay(1000);
+		error  = z77_i2c_readByte( dev, buf );
+		error1 = z77_i2c_setAckn( dev );
+		if( error )
+		{
+			goto out_cleanup;
+		}
+		if( error1 ) 
+		{
+			error = error1;
+			goto out_cleanup;
+		}
+		buf++;
+	}
+	/* OSS_MikroDelay() is blocking for some OS
+	 * give other tasks a chance:-) */
+	udelay(1000);
+	error  = z77_i2c_readByte( dev, buf );
+	z77_i2c_notAckn(dev);
+
+out_cleanup:
+	if( stop )
+		stopErr = z77_i2c_stop( dev );
+	if( error )
+		return( error );
+	return( stopErr );
+}
+
+/*******************************************************************/
+/** Write a defined length of bytes
+ *
+ * \param dev			\IN net_device struct for this NIC
+ * \param msg			\INOUT i2c message struct for
+ *				this transfer. Send data will
+ *				be used from this message
+ * \param stop			\IN if stop is set. the access is
+ *				terminated after the transfer
+ *
+ * \return			0 or error code
+ *
+ * \brief 
+ * Write a defined length of bytes
+ */
+u32 z77_i2c_write_msg(struct net_device *dev, const struct z77_i2c_msg_st *msg, int stop)
+{
+	u32 error = 0, error1 = 0, stopErr = 0;
+	u32 len = msg->len;
+	const u8 *buf = msg->buf;
+
+	if( (error = z77_i2c_start( dev )) )
+		goto out_cleanup;
+	/* send device address */
+	if( (error = z77_i2c_sendByte( dev, msg->addr | SMB_WRITE )) )
+		goto out_cleanup;
+	if( (error = z77_i2c_checkAckn( dev )) )
+		goto out_cleanup;
+
+	/* send data */
+	while( len-- ) {
+		/* OSS_MikroDelay() is blocking for some OS
+		 * give other tasks a chance:-) */
+		udelay(10000);
+		error  = z77_i2c_sendByte( dev, *buf++ );
+		error1 = z77_i2c_checkAckn( dev );
+		if( error )
+			goto out_cleanup;
+		if( error1 ) {
+			error = error1;
+			goto out_cleanup;
+		}
+	}
+
+out_cleanup:
+	if( stop )
+		stopErr = z77_i2c_stop( dev );
+	if( error )
+	    return( error );
+	return( stopErr );
+}
+
+static int32 z77_i2c_xfer_msg(struct net_device *dev, struct z77_i2c_msg_st msg[], u32 num)
+{
+	struct z77_i2c_msg_st *pmsg;
+	u32 i;
+	int32 error = SMB_ERR_NO;
+	int32 doStop = 0, didStop = 0;
+
+	if( !msg ) {
+		error = SMB_ERR_PARAM;
+		goto out_err;
+	}
+
+	/* tingle through messages */
+	for( i = 0; error == SMB_ERR_NO && i < num; i++ ){
+		pmsg = &msg[i];
+
+		/* sanity checks */
+		if( !pmsg || pmsg->flags & I2C_M_TEN ){
+			error = SMB_ERR_PARAM;
+			goto out_err;
+		}
+		if(i == (num - 1)) /* send stop on last packet */
+			doStop = 1;
+
+		if( pmsg->flags & I2C_M_RD )
+			error = z77_i2c_read_msg( dev, pmsg, doStop );
+		else
+			error = z77_i2c_write_msg( dev, pmsg, doStop );
+
+		if(i != (num - 1)) /* do small delays between packets */
+			z77_i2c_delay();
+
+		if( doStop && !error )
+			didStop = 1;
+	}
+out_err:
+	return error;
+}
+
+/*******************************************************************/
+/** attribute function to read MAC from EEPROM
+ *
+ * \buf		/OUT MAC address as a string in format 12:56:89:cb:fe:0e
+ *
+ * \return	the string length
+ *
+ */
+static ssize_t z77_eeprod_mac_show(struct device *dev,
+				  struct device_attribute *attr,
+				  char *buf)
+{
+	struct net_device *ndev = to_net_dev(dev);
+	unsigned char mac[6] = {0};
+	unsigned char msgbuf[8] = {0};
+	struct z77_i2c_msg_st i2cmes[2];
+
+
+	i2cmes[0].addr = 0xa0;
+	i2cmes[0].buf = msgbuf;
+	// Write offset in the EEPROM
+	msgbuf[0] = 0;
+	i2cmes[0].flags = I2C_M_WR;
+	i2cmes[0].len = 1;
+
+	i2cmes[1].addr = 0xa0;
+	i2cmes[1].buf = msgbuf;
+	// Read magic/parity + 6 Byte MAC
+	i2cmes[1].flags = I2C_M_RD;
+	i2cmes[1].len = 7;
+	
+	if (z77_i2c_xfer_msg(ndev, i2cmes, 2)) {
+		dev_err(dev, "*** EEPROM Read ERROR\n");
+		return 0;
+	}
+
+	/* Copy MAC address */
+	mac[0] = msgbuf[1];
+	mac[1] = msgbuf[2];
+	mac[2] = msgbuf[3];
+	mac[3] = msgbuf[4];
+	mac[4] = msgbuf[5];
+	mac[5] = msgbuf[6];
+
+	return sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x\n",
+		mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+
+/*******************************************************************/
+/** attribute function to write MAC to EEPROM
+ *
+ * \buf		/OUT MAC address as a string in format 
+ *		12:56:89:cb:fe:0e
+ *
+ * \return	the number of accepted bytes => 
+ *		will be always equal to count
+ *
+ */
+static ssize_t z77_eeprod_mac_store(struct device *dev,
+				   struct device_attribute *attr,
+				   const char *buf, size_t count)
+{
+	struct z77_i2c_msg_st i2cmes;
+	struct net_device *ndev = to_net_dev(dev);
+	int macIndex = 0;
+	long val;
+	char tmpBuffer[50];
+	u8 msgbuf[8];
+	char *tmpBufferPtr;
+	char *token;
+
+	if (!buf || (count > 50))
+		return count;
+    
+	/* Copy input buffer */
+	snprintf(tmpBuffer, 50, "%s", buf);
+	tmpBufferPtr = tmpBuffer;
+
+	/* Modify string for seperation */
+	token = strsep(&tmpBufferPtr, ":");
+
+	macIndex = 0;
+	while (token != NULL)
+	{
+		/* Interpret string as hex value */
+		if (kstrtol(token, 16, &val)) {
+			dev_err(dev,
+				"%s: ERROR: Wrong format for value (should be decimal)\n",
+				__func__);
+			return count;
+		}
+		/* Write data to message buffer */
+		msgbuf[2 + macIndex] = (unsigned char)(val & 0xFF);
+		/* Increment mac address and break if we have last byte of MAC */
+		macIndex ++;
+		if (macIndex >= 6)
+			break;
+		/* Get next token */
+		token = strsep(&tmpBufferPtr, ":");
+	}
+
+	i2cmes.addr  = 0xa0;
+	i2cmes.buf   = msgbuf;
+	// Write offset, start bit.
+	i2cmes.flags = I2C_M_WR;
+	i2cmes.len   = 1;
+
+	/* Address */
+	msgbuf[0] = 0;
+	/* MAC_ID_MAGIC | parity  */
+	msgbuf[1] = 0xB0 /*| CalcParity(FdoData->PermanentAddress,sizeof(FdoData->PermanentAddress))*/;
+	i2cmes.len = 8;
+
+	/* Write MAC to EEPROD */
+	z77_i2c_xfer_msg(ndev, &i2cmes, 1);
+
+	return count;
+}
+static DEVICE_ATTR_RW(z77_eeprod_mac);
 
 /*******************************************************************/
 /** finding a board ident EEPROM to read MAC from
@@ -2399,15 +2928,17 @@ static int z77_get_mac_from_board_id(u8 *mac)
  */
 static int chipset_init(struct net_device *dev, u32 first_init)
 {
-	u32 moder = 0, i=0;
+	u32 moder = 0;
 	struct z77_private *np = netdev_priv(dev);
-	u8 mac[6] = {0,0,0,0,0,0};
-	u32 mac0reg=0, mac1reg=0;
+	struct z77_i2c_msg_st i2cmes[2];
+	u8 mac[6] = {0, 0, 0, 0, 0, 0};
+	u8 msgbuf[8] = {0};
+	u32 mac0reg = 0, mac1reg = 0;
 
 	Z77DBG(ETHT_MESSAGE_LVL1, "--> %s(%d)\n", __FUNCTION__, first_init);
 
 	z77_reset( dev );
-	if( first_init==0 ) { /* 1. Check what's already in the MAC Registers */
+	if (first_init == 0) { /* 1. Check what's already in the MAC Registers */
 		mac0reg = Z77READ_D32( Z077_BASE, Z077_REG_MAC_ADDR0 );
 		mac1reg = Z77READ_D32( Z077_BASE, Z077_REG_MAC_ADDR1 );
 		mac[0] = ( mac1reg >> 8  ) & 0xff;
@@ -2416,21 +2947,39 @@ static int chipset_init(struct net_device *dev, u32 first_init)
 		mac[3] = ( mac0reg >> 16 ) & 0xff;
 		mac[4] = ( mac0reg >> 8  ) & 0xff;
 		mac[5] = ( mac0reg >> 0  ) & 0xff;
-		if ( is_valid_ether_addr( mac )) {
-			printk(KERN_INFO
-				"current MAC %02x:%02x:%02x:%02x:%02x:%02x is valid, keeping it.\n",
-				mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-			memcpy(dev->dev_addr, mac, 6);
-			goto cont_init;
-		}
+		//if (is_valid_ether_addr( mac )) {
+		//	printk(KERN_INFO
+		//		"current MAC %02x:%02x:%02x:%02x:%02x:%02x is valid, keeping it.\n",
+		//		mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+		//	memcpy(dev->dev_addr, mac, 6);
+		//	goto cont_init;
+		//}
 
 		/* 2. initial MAC wasn't valid, check for attached MAC EEPROM */
 		printk(KERN_INFO
 			"current MAC %02x:%02x:%02x:%02x:%02x:%02x is invalid, try get one from an attached MAC EEPROM.\n",
-			  mac[0], mac[1], mac[2], mac[3], mac[4], mac[5] );
-		for (i=0; i < 6; i++ )
-			mac[i] = z77_read_byte_data( dev, i+1 );
+			mac[0], mac[1], mac[2], mac[3], mac[4], mac[5] );
 
+		i2cmes[0].addr = 0xa0;
+		i2cmes[0].buf = msgbuf;
+		// Write offset in the EEPROM
+		msgbuf[0] = 0;
+		i2cmes[0].flags = I2C_M_WR;
+		i2cmes[0].len = 1;
+
+		i2cmes[1].addr = 0xa0;
+		i2cmes[1].buf = msgbuf;
+		// Read magic/parity + 6 Byte MAC
+		i2cmes[1].flags = I2C_M_RD;
+		i2cmes[1].len = 7;
+
+		z77_i2c_xfer_msg(dev, i2cmes, 2);
+		mac[0] = msgbuf[1];
+		mac[1] = msgbuf[2];
+		mac[2] = msgbuf[3];
+		mac[3] = msgbuf[4];
+		mac[4] = msgbuf[5];
+		mac[5] = msgbuf[6];
 		if ( is_valid_ether_addr(mac) ) {
 			printk(KERN_INFO
 				"got MAC %02x:%02x:%02x:%02x:%02x:%02x from MAC EEPROM, assigning it.\n",
@@ -2728,7 +3277,6 @@ static struct net_device_stats *z77_get_stats(struct net_device *dev)
  */
 int men_16z077_probe( CHAMELEON_UNIT_T *chu )
 {
-
 	u32 phys_addr = 0;
 	struct net_device *dev = NULL;
 	struct z77_private *np = NULL;
@@ -2754,14 +3302,13 @@ int men_16z077_probe( CHAMELEON_UNIT_T *chu )
 	phys_addr = pci_resource_start(chu->pdev, chu->bar) + chu->offset;
 	dev->base_addr = (unsigned long)ioremap_nocache(phys_addr,
 			(u32)Z77_CFGREG_SIZE );
-	dev->irq       = chu->irq;
+	dev->irq = chu->irq;
 
 	if( dev_alloc_name( dev, "eth%d") < 0)
 		printk("*** warning: couldnt retrieve a name for Z77\n");
 
 	/* setup the phy Info within the private z77_private struct */
 	np = netdev_priv(dev);
-
 	np->pdev = chu->pdev;
 	spin_lock_init(&np->lock);
 	pci_set_drvdata(chu->pdev, dev);
@@ -2873,6 +3420,10 @@ int men_16z077_probe( CHAMELEON_UNIT_T *chu )
 	} else {
 		if (register_netdev(dev) == 0) {
 			if (device_create_file(&dev->dev, &dev_attr_linkstate))
+				dev_err(&dev->dev,
+						"Error creating sysfs file\n");
+			printk(KERN_ALERT "CREATE SYSFS!!!!!\n");
+			if (device_create_file(&dev->dev, &dev_attr_z77_eeprod_mac))
 				dev_err(&dev->dev,
 						"Error creating sysfs file\n");
 		}

--- a/DRIVERS/ETH_16Z077/DRIVER/men_16z077_eth.c
+++ b/DRIVERS/ETH_16Z077/DRIVER/men_16z077_eth.c
@@ -2938,7 +2938,8 @@ static int chipset_init(struct net_device *dev, u32 first_init)
 	Z77DBG(ETHT_MESSAGE_LVL1, "--> %s(%d)\n", __FUNCTION__, first_init);
 
 	z77_reset( dev );
-	if (first_init == 0) { /* 1. Check what's already in the MAC Registers */
+	if (first_init == 0) {
+		/* 1. Check what's already in the MAC Registers */
 		mac0reg = Z77READ_D32( Z077_BASE, Z077_REG_MAC_ADDR0 );
 		mac1reg = Z77READ_D32( Z077_BASE, Z077_REG_MAC_ADDR1 );
 		mac[0] = ( mac1reg >> 8  ) & 0xff;
@@ -2947,13 +2948,13 @@ static int chipset_init(struct net_device *dev, u32 first_init)
 		mac[3] = ( mac0reg >> 16 ) & 0xff;
 		mac[4] = ( mac0reg >> 8  ) & 0xff;
 		mac[5] = ( mac0reg >> 0  ) & 0xff;
-		//if (is_valid_ether_addr( mac )) {
-		//	printk(KERN_INFO
-		//		"current MAC %02x:%02x:%02x:%02x:%02x:%02x is valid, keeping it.\n",
-		//		mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-		//	memcpy(dev->dev_addr, mac, 6);
-		//	goto cont_init;
-		//}
+		if (is_valid_ether_addr( mac )) {
+			printk(KERN_INFO
+				"current MAC %02x:%02x:%02x:%02x:%02x:%02x is valid, keeping it.\n",
+				mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+			memcpy(dev->dev_addr, mac, 6);
+			goto cont_init;
+		}
 
 		/* 2. initial MAC wasn't valid, check for attached MAC EEPROM */
 		printk(KERN_INFO


### PR DESCRIPTION
Hello,

I would like to introduce a new version of the 13Z077-90 native driver:

This version was created to enable access to the bit-banging I2C interface of the FPGA and to provide read and write functions for a connected EEPROM with a MAC address. This functionality was copied from the windows driver and adapted for Linux.

To access the I2C a sysfs note will be created by the driver called z77_eeprod_mac. This note can be found at:
   **_/sys/class/net/\<interface name\>/z77_eeprod_mac_**

In addition a new module parameter was added to select if the sysfs note is created or not, to prevent a customer from accidentally changing the MAC address:

**maceepromacc**
   - 0      no sysfs note will be created
   - !=0  create sysfs note z77_eeprod_mac to access EEPROM attached to FPGA


**Usage:**
To create the sysfs note load the driver as followed:
   _# modprobe men_lx_z77 maceepromacc=1_ 

To read the MAC address :
   _# sudo cat /sys/class/net/\<interface name\>/z77_eeprod_mac_

To write the MAC address :
   _# sudo sh -c 'echo -n \<MAC address\> \> /sys/class/net/\<interface name\>/z77_eeprod_mac'_

The MAC address must have the following format:
   **"12:34:56:78:9a:bc"**


Before adding these changes, please check the diff, make a code review and perform a full functional test of the 13Z077-90. This driver is used in many projects and the new driver version has not been tested completely yet.

Any remarks, wishes or questions are welcome

Regards,
Andreas